### PR TITLE
Added bsc and fixed threshold issue

### DIFF
--- a/src/containers/NewProposalContainer/index.tsx
+++ b/src/containers/NewProposalContainer/index.tsx
@@ -65,7 +65,7 @@ export function NewProposalContainer() {
         form.assetContractAddress ||
         '0x0000000000000000000000000000000000000000';
       value['threshold'] = bignumber(form.threshold)
-        .mul(10 ** form.assetDecimals)
+        .mul(bignumber(10 ** form.assetDecimals))
         .toString();
     }
 

--- a/src/containers/NewProposalContainer/index.tsx
+++ b/src/containers/NewProposalContainer/index.tsx
@@ -65,7 +65,7 @@ export function NewProposalContainer() {
         form.assetContractAddress ||
         '0x0000000000000000000000000000000000000000';
       value['threshold'] = bignumber(form.threshold)
-        .mul(bignumber(10 ** form.assetDecimals))
+        .mul(10 ** form.assetDecimals)
         .toString();
     }
 
@@ -92,6 +92,7 @@ export function NewProposalContainer() {
         setStep(1);
       })
       .catch(error => {
+        console.error(error);
         if (error?.error?.errors) {
           setErrors(error?.error?.errors || [error.message]);
         } else {
@@ -231,6 +232,7 @@ export function NewProposalContainer() {
               <Select value={form.chainId} onChange={updateSelect('chainId')}>
                 <option value={30}>RSK</option>
                 <option value={1}>Ethereum</option>
+                <option value={56}>Binance Smart Chain</option>
                 <optgroup label="Testnets">
                   <option value={31}>RSK testnet</option>
                 </optgroup>

--- a/src/utils/explorers.ts
+++ b/src/utils/explorers.ts
@@ -3,4 +3,5 @@ export const explorers: { [key: number]: string } = {
   1: 'https://etherscan.io',
   30: 'https://explorer.rsk.co',
   31: 'https://explorer.testnet.rsk.co',
+  56: 'https://bscxplorer.com',
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -40,6 +40,7 @@ const networks: Record<number, string> = {
   1: 'Ethereum',
   30: 'RSK',
   31: 'RSK testnet',
+  56: 'Binance Smart Chain',
 };
 
 export const chainIdToNetworkName = (chainId: number) =>


### PR DESCRIPTION
- Added BSC chain to frontend
- In the current version, on the form to add a new monitoring wallet if the threshold is greater than 100 there is an input validation error. I think this is a backend issue but I added some logging to make sure