### PR TITLE
Fix/foreign date string login

### DIFF
--- a/src/containers/EngageWalletContainer/index.tsx
+++ b/src/containers/EngageWalletContainer/index.tsx
@@ -30,7 +30,7 @@ function WalletConsumer() {
   useEffect(() => {
     if (wallet.wallet?.getAddressString()) {
       const sign = async () => {
-        const date = new Date().toString();
+        const date = new Date().toUTCString();
         const message = `Login to backend on ${date}`;
         const signature = await wallet.signMessage(
           `Login to backend on ${date}`,

--- a/src/containers/NewProposalContainer/index.tsx
+++ b/src/containers/NewProposalContainer/index.tsx
@@ -64,9 +64,12 @@ export function NewProposalContainer() {
       value['assetContractAddress'] =
         form.assetContractAddress ||
         '0x0000000000000000000000000000000000000000';
-      value['threshold'] = bignumber(form.threshold)
+      const threshold = bignumber(form.threshold)
         .mul(10 ** form.assetDecimals)
         .toString();
+      value['threshold'] = Number(threshold).toLocaleString('fullwide', {
+        useGrouping: false,
+      });
     }
 
     if (!value['exchangeName']) {


### PR DESCRIPTION
This PR has 2 small fixes:
1. Using Date.toUTCString() instead of Date.toString() for login to fix the issue Ororo was having where the web3.js function for decrypting the message can't handle foreign characters
2. A fix from months ago that I forgot to make a PR for - currently the threshold cannot be >100 and the change to NewProposalContainer fixes this